### PR TITLE
fix: changed references to old repo/module name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,10 @@ COPY . .
 
 # Build the application
 RUN mkdir -p out/bin
-RUN go build -o out/bin/webinar-scale-up-app.out cmd/app/main.go
+RUN go build -o out/bin/sample-twilio-go.out cmd/app/main.go
 
 # Expose port 8080
 EXPOSE 8080
 
 # Command to run the executable
-CMD ["./out/bin/webinar-scale-up-app.out"]
+CMD ["./out/bin/sample-twilio-go.out"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-NAME=webinar-scale-up-app
+NAME=sample-twilio-go
 BINARY_NAME=${NAME}.out
 # Enables support for tools such as https://github.com/rakyll/gotest
 TEST_COMMAND ?= go test ./...

--- a/README.md
+++ b/README.md
@@ -112,30 +112,30 @@ For Twilio Go SDK documentation, examples, and code snippets, please refer to th
 
 Areas of interest in the code base that serve as examples for using the Twilio SDK and troubleshooting errors.
 
-- Initializing the Twilio SDK client. A pointer to this client instance is then saved in each application's service `client` field for later use (i.e. [SMSService.client](https://code.hq.twilio.com/twilio/go-review-rewards-example-app/blob/main/pkg/sms/sms_service.go#L27))
+- Initializing the Twilio SDK client. A pointer to this client instance is then saved in each application's service `client` field for later use (i.e. [SMSService.client](https://github.com/twilio-labs/sample-twilio-go/blob/main/pkg/sms/sms_service.go#L29))
 
-    https://code.hq.twilio.com/twilio/go-review-rewards-example-app/blob/main/main.go#L44
+    https://github.com/twilio-labs/sample-twilio-go/blob/main/cmd/app/main.go#L104
 
 - Sending an SMS message with the SDK
     
-    https://code.hq.twilio.com/twilio/go-review-rewards-example-app/blob/main/pkg/sms/sms_service.go#L102
+    https://github.com/twilio-labs/sample-twilio-go/blob/main/pkg/sms/sms_service.go#L102
 
 - Initiating a voice call with the SDK
 
-    https://code.hq.twilio.com/twilio/go-review-rewards-example-app/blob/main/pkg/voice/voice_service.go#L38
+    https://github.com/twilio-labs/sample-twilio-go/blob/main/pkg/voice/voice_service.go#L38
 
 - Generating TwiML using the SDK
 
-    https://code.hq.twilio.com/twilio/go-review-rewards-example-app/blob/main/pkg/message/message.go#L48
+    https://github.com/twilio-labs/sample-twilio-go/blob/main/pkg/message/message.go#L48
 
-- Initializing the SDK Request Validator. A pointer to this request validator instance is then saved in the application controller `reqValidator` field for later use (i.e. [ReviewController.reqValidator](https://code.hq.twilio.com/twilio/go-review-rewards-example-app/blob/main/pkg/controller/review_controller.go#L35))
+- Initializing the SDK Request Validator. A pointer to this request validator instance is then saved in the application controller `reqValidator` field for later use (i.e. [ReviewController.reqValidator](https://github.com/twilio-labs/sample-twilio-go/blob/main/pkg/controller/review_controller.go#L35))
 
-    https://code.hq.twilio.com/twilio/go-review-rewards-example-app/blob/main/main.go#L64
+    https://github.com/twilio-labs/sample-twilio-go/blob/main/cmd/app/main.go#L124
 
 - Using the Request Validator to validate requests are coming from Twilio
 
-    https://code.hq.twilio.com/twilio/go-review-rewards-example-app/blob/main/pkg/controller/review_controller.go#L153
+    https://github.com/twilio-labs/sample-twilio-go/blob/main/pkg/controller/review_controller.go#L153
 
 - Debugging errors returned in an API response while using the SDK
 
-    https://code.hq.twilio.com/twilio/go-review-rewards-example-app/blob/main/pkg/sms/sms_service.go#L117
+    https://github.com/twilio-labs/sample-twilio-go/blob/main/pkg/sms/sms_service.go#L117

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module code.hq.twilio.com/twilio/review-rewards-example-app
+module github.com/twilio-labs/sample-twilio-go
 
 go 1.19
 

--- a/pkg/controller/review_controller_test.go
+++ b/pkg/controller/review_controller_test.go
@@ -5,10 +5,10 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"code.hq.twilio.com/twilio/review-rewards-example-app/pkg/sms"
-	"code.hq.twilio.com/twilio/review-rewards-example-app/pkg/voice"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
+	"github.com/twilio-labs/sample-twilio-go/pkg/sms"
+	"github.com/twilio-labs/sample-twilio-go/pkg/voice"
 	twilioClient "github.com/twilio/twilio-go/client"
 )
 

--- a/services/.env
+++ b/services/.env
@@ -1,3 +1,3 @@
-IMAGE_NAME=${IMAGE_NAME:-webinar-scale-up-app}
+IMAGE_NAME=${IMAGE_NAME:-sample-twilio-go}
 IMAGE_TAG=${IMAGE_TAG:-latest}
 LOG_LEVEL=${LOG_LEVEL:-info}


### PR DESCRIPTION
Changed references to the old repo/module name in:
- Docker related files
- Makefile
- README
- Module imports

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
